### PR TITLE
Improve npm auto-publish GitHub Actions setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,8 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 10
     versioning-strategy: "lockfile-only"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     pull_request:
         branches: [main]
 
+permissions:
+    contents: read
+
 jobs:
     test:
         name: Test & Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
 
             - name: Setup pnpm
               uses: pnpm/action-setup@v4
-              with:
-                  version: 9
 
             - name: Setup Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4
@@ -50,6 +48,10 @@ jobs:
 
             - name: Build
               run: pnpm build
+
+            - name: Verify package contents
+              if: github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.node-version == '22.x'
+              run: npm pack --dry-run
 
             - name: Upload build artifacts
               if: matrix.node-version == '20.x'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,8 +33,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,35 +1,64 @@
 name: NPM Publish
+
 on:
   workflow_run:
     workflows: [CI]
     branches: [main]
     types: [completed]
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: npm-publish-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   publish:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+
     steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          version: latest
-      - uses: actions/setup-node@v4
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: 22.x
-          cache: "pnpm"
-      - run: pnpm install --frozen-lockfile
-      - name: Create Release Pull Request or Publish to npm
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Upgrade npm (Trusted Publishing / provenance)
+        run: npm install -g npm@latest
+
+      - name: Create Release PR or publish to npm
         id: changesets
         uses: changesets/action@v1
         with:
           publish: pnpm run release
+          title: Version Packages
+          commit: Version Packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish summary
+        if: steps.changesets.outputs.published == 'true'
+        run: echo "Published to npm — ${{ steps.changesets.outputs.publishedPackages }}"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "vite": "^6.0.0",
     "vitest": "^2.1.4"
   },
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@10.33.4",
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/package.json
+++ b/package.json
@@ -82,6 +82,11 @@
     "vite": "^6.0.0",
     "vitest": "^2.1.4"
   },
+  "packageManager": "pnpm@9.15.9",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens the existing Changesets + `workflow_run` npm publish pipeline and aligns CI with release best practices.

## Changes

### `publish.yml`
- Checkout the **CI-tested commit** (`workflow_run.head_sha`) with full history
- **Fork guard**: skip publish when the triggering CI run came from a fork
- **Least-privilege permissions** at workflow level; publish job gets `contents`, `pull-requests`, and `id-token` (OIDC/provenance)
- **Concurrency** keyed by branch with `cancel-in-progress: false` so releases are not interrupted
- Align with CI: `checkout@v4`, `pnpm/action-setup@v4` (pnpm 9), Node 22
- Upgrade npm before publish (supports Trusted Publishing + provenance)
- Explicit Changesets PR title/commit messages and publish summary step

### `ci.yml`
- Default `permissions: contents: read`
- On pushes to `main` (Node 22): `npm pack --dry-run` to catch bad `files` / `exports` before release

### `dependabot.yml`
- Weekly **github-actions** dependency updates

### `package.json`
- `packageManager: pnpm@9.15.9` (matches CI)
- `publishConfig.provenance: true` and public access

## Follow-up (manual, on npmjs.com)

When ready, configure **Trusted Publishing** for `three-iges-loader`:
- Repository: `KonseptDesign/three-iges-loader` (or your canonical org/repo)
- Workflow file: **`publish.yml`**
- Then remove the `NPM_TOKEN` repository secret and drop it from the workflow `env`

Until then, keep using the existing `NPM_TOKEN` (Automation-type granular token).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0beb286a-f170-451f-8250-d0246fc47fa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0beb286a-f170-451f-8250-d0246fc47fa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

