### PR TITLE
Set up dev branch workflow for Changesets, CI, and Dependabot.

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,7 @@
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "dev",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
       day: monday
@@ -18,6 +19,7 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
     open-pull-requests-limit: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,4 @@
-# Changesets: "Version Packages" PRs + npm publish via Trusted Publishing (OIDC).
-# Runs only after CI succeeds on main (not in parallel with tests).
+# Changesets on dev (Version Packages PRs) + npm publish on main (Trusted Publishing / OIDC).
 # @see https://docs.npmjs.com/trusted-publishers
 # @see docs/GITHUB_SETUP.md
 name: Publish
@@ -8,7 +7,7 @@ on:
   workflow_run:
     workflows: [CI]
     types: [completed]
-    branches: [main]
+    branches: [main, dev]
   workflow_dispatch:
 
 env:
@@ -24,12 +23,49 @@ permissions:
   pull-requests: write
 
 jobs:
-  publish:
-    name: Version & publish
+  version:
+    name: Version packages (dev)
     runs-on: ubuntu-latest
     if: >
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'dev')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Changesets (version PR)
+        uses: changesets/action@v1
+        with:
+          version: pnpm run version-packages
+          commit: "chore(release): version packages"
+          title: "chore(release): version packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: Publish to npm (main)
+    runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main')
 
     steps:
       - name: Checkout
@@ -51,14 +87,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Changesets
+      - name: Publish to npm
         id: changesets
         uses: changesets/action@v1
         with:
-          version: pnpm run version-packages
           publish: npm publish --access public
-          commit: "chore(release): version packages"
-          title: "chore(release): version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -66,7 +99,7 @@ jobs:
         if: steps.changesets.outputs.published == 'true'
         run: |
           echo "### Published to npm" >> "$GITHUB_STEP_SUMMARY"
-          echo "Published with \`npm publish\` (Trusted Publishing / OIDC)." >> "$GITHUB_STEP_SUMMARY"
+          echo "Published with npm Trusted Publishing (OIDC)." >> "$GITHUB_STEP_SUMMARY"
           echo '```json' >> "$GITHUB_STEP_SUMMARY"
           echo '${{ steps.changesets.outputs.publishedPackages }}' >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,10 +18,21 @@ pnpm dev:example   # optional: visual check at http://localhost:3000
 
 See [docs/ROADMAP.md](docs/ROADMAP.md) for planned entity types and phases. **Phase B** (wireframe / curves) is the current focus; surfaces and B-rep are deferred unless discussed first.
 
+## Branch strategy
+
+| Branch | Purpose |
+|--------|---------|
+| **`dev`** | Day-to-day development. Open PRs here. Dependabot targets this branch. |
+| **`main`** | Release line only. Merge `dev` → `main` when you are ready to ship. CI + npm publish run on `main`. |
+
+**Contributors:** branch from `dev`, open PRs against `dev`, add a changeset for user-facing changes.
+
+**Maintainers:** when releasing, merge `dev` → `main`. Changesets opens **Version Packages** PRs against `dev`; after merging that, merge `dev` → `main` to trigger npm publish.
+
 ## Development workflow
 
 1. **Fork** the repo (or branch in-repo if you are a maintainer).
-2. **Create a branch** from `main`: `feat/type-102-composite-curve`, `fix/de-sequence-parse`, etc.
+2. **Create a branch** from `dev`: `feat/type-102-composite-curve`, `fix/de-sequence-parse`, etc.
 3. **Make focused changes** — one entity type or one logical fix per PR when possible.
 4. **Add tests** — place IGES fixtures in `test/fixtures/` (80-column lines; see [test/fixtures/README.md](test/fixtures/README.md)).
 5. **Run checks** before opening a PR:
@@ -41,7 +52,7 @@ See [docs/ROADMAP.md](docs/ROADMAP.md) for planned entity types and phases. **Ph
 
    Choose `patch` / `minor` / `major` per [Semantic Versioning](https://semver.org/). Describe the user-facing impact.
 
-7. **Open a pull request** against `main` with a clear description and link any related issues.
+7. **Open a pull request** against `dev` with a clear description and link any related issues.
 
 ## Architecture (where to edit)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,36 +2,39 @@
 
 This repo uses **[Changesets](https://github.com/changesets/changesets)** for semver, changelogs, GitHub releases, and npm publish.
 
-## How it works (two phases)
+## Branches
+
+| Branch | Role |
+|--------|------|
+| **`dev`** | Integration — features, Dependabot, **Version Packages** PRs |
+| **`main`** | Release line — merge `dev` here to ship to npm |
+
+## How it works
 
 ```mermaid
 flowchart LR
-  A[Feature PR + changeset] --> B[Merge to main]
-  B --> C[CI passes]
-  C --> D[Publish workflow]
-  D --> E{Pending .changeset files?}
-  E -->|Yes| F[Version Packages PR]
-  F --> G[Merge Version PR]
-  G --> H[npm publish + GitHub release]
-  E -->|No, nothing to version| I[Skip or publish if version PR just merged]
+  A[Feature + changeset → dev] --> B[CI on dev]
+  B --> C[Version Packages PR → dev]
+  C --> D[Merge Version PR]
+  D --> E[Merge dev → main]
+  E --> F[CI on main]
+  F --> G[Publish to npm]
 ```
 
-**Phase 1 — version (no npm upload)**  
-You merge feature work that includes a `.changeset/*.md` file. The **Publish** workflow sees pending changesets and opens a **“Version Packages”** PR. That PR only updates `package.json`, `CHANGELOG.md`, and related files.
+**Phase 1 — version (on `dev`)**  
+Merge feature work with a `.changeset/*.md` file to **`dev`**. After CI passes, **Publish → Version packages (dev)** opens a **“Version Packages”** PR against `dev` (bumps `package.json`, updates `CHANGELOG.md`).
 
-**Phase 2 — publish**  
-You merge the Version Packages PR. The next run has **no** pending changesets, so the workflow runs **`npm publish --access public`**. Authentication uses **[npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers)** (OIDC). There is no `NPM_TOKEN` secret. One-time npm/GitHub setup: **[docs/GITHUB_SETUP.md](docs/GITHUB_SETUP.md)**.
+**Phase 2 — ship (merge to `main`)**  
+Review and merge the Version Packages PR on `dev`, then merge **`dev` → `main`**. After CI on `main`, **Publish → Publish to npm** uploads the new version (OIDC).
 
-`prepublishOnly` runs build, typecheck, and tests before publish.
+Changelog entries come from changeset summaries and `@changesets/changelog-github` (links PRs/issues). You do not edit `CHANGELOG.md` by hand for releases.
 
-## Day-to-day routine
+## Maintainer routine
 
-1. On each **user-facing** PR: `pnpm changeset` and commit the file under `.changeset/`.
-2. Merge to **`main`** and wait for **CI**.
-3. If **“Version Packages”** appears → review `CHANGELOG.md` → merge it.
-4. After that merge, **Publish** uploads to npm and creates the GitHub release.
-
-You do not run `npm publish` locally unless CI is broken.
+1. Merge feature PRs to **`dev`** (each user-facing change includes a changeset).
+2. When **Version Packages** opens on `dev` → review `CHANGELOG.md` → merge it.
+3. Merge **`dev` → `main`** when ready to release.
+4. Confirm **Publish** on `main` succeeds.
 
 ## Versioning rules (semver)
 
@@ -68,11 +71,10 @@ One-time configuration: **[docs/GITHUB_SETUP.md](docs/GITHUB_SETUP.md)**.
 
 | Problem | Check |
 |---------|--------|
-| Version PR never opens | Changeset file merged to `main`? `publish.yml` enabled on `main`? |
-| Publish fails | Trusted Publishing: workflow **`publish.yml`**, repo match, `id-token: write` |
-| `ENEEDAUTH` / 401 | Trusted publisher not configured or wrong workflow filename on npm |
+| Version PR never opens | Changeset merged to **`dev`**? CI passed on `dev`? |
+| Publish fails with “already published” | Version on `main` matches npm — bump via Changesets on `dev` before merging to `main` again |
+| `ENEEDAUTH` / 401 | Trusted Publishing: workflow **`publish.yml`**, repo match, `id-token: write` |
 | Wrong version bumped | Changeset type in `.changeset/*.md` |
-| Changelog missing PR links | `@changesets/changelog-github` repo in `.changeset/config.json` |
 
 ## Manual publish (emergency only)
 

--- a/docs/GITHUB_SETUP.md
+++ b/docs/GITHUB_SETUP.md
@@ -27,12 +27,12 @@ This repo publishes with **[npm Trusted Publishing](https://docs.npmjs.com/trust
 
 ### What the publish workflow does
 
-After **CI** succeeds on **`main`**, [`.github/workflows/publish.yml`](../.github/workflows/publish.yml) runs (not in parallel with tests):
+After **CI** succeeds on **`dev`** or **`main`**, [`.github/workflows/publish.yml`](../.github/workflows/publish.yml) runs:
 
-| Situation | What happens |
-|-----------|----------------|
-| There are files in `.changeset/` | Opens or updates a **“Version Packages”** PR (bumps version + `CHANGELOG.md`). **No publish yet.** |
-| There are **no** pending changesets (typically right after you merge that Version PR) | Runs **`npm publish --access public`**. npm verifies the job against your trusted publisher config and uploads the package (with provenance). |
+| Branch | Job | What happens |
+|--------|-----|----------------|
+| **`dev`** | Version packages | Opens **Version Packages** PR if `.changeset/` files exist |
+| **`main`** | Publish to npm | Runs **`npm publish`** (OIDC); fails if that version already exists |
 
 So you will **not** see a separate `run: npm publish` step in the YAML list — the [Changesets action](https://github.com/changesets/action) runs it for you via its `publish:` input when it is time to release. On npm, the allowed action **`npm publish`** still matches that command.
 


### PR DESCRIPTION
Version Packages PRs target dev; npm publish runs on main only after CI. Dependabot opens PRs against dev. Document branch strategy in CONTRIBUTING and RELEASING.

## Summary

<!-- What does this PR do? Link issues: Fixes # -->

## Type of change

- [ ] Bug fix (patch)
- [ ] New feature / entity (minor)
- [ ] Breaking change (major)
- [ ] Documentation only
- [ x ] Internal refactor (no user-visible change)

## Changeset

- [ ] I have run `pnpm changeset` (required for user-visible changes to `three-iges-loader`)
- [ ] Not needed (docs-only / internal-only — explain below)

## Checklist

- [ ] `pnpm type-check` passes
- [ ] `pnpm lint` and `pnpm format:check` pass
- [ ] `pnpm test` passes
- [ ] New IGES fixtures use **80-column** lines (section letter in column 73) if applicable
- [ ] Entity work follows [docs/ENTITY_IMPLEMENTATION.md](../docs/ENTITY_IMPLEMENTATION.md)

## AI-assisted

- [ ] I used AI tools and reviewed the diff against [AGENTS.md](../AGENTS.md)
