### PR TITLE
Update version to 2.1.1 in package.json and enhance publishing workfl…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,5 @@
 # Changesets on dev (Version Packages PRs) + npm publish on main (Trusted Publishing / OIDC).
+# Publish on main runs only when package.json version is not yet on npm.
 # @see https://docs.npmjs.com/trusted-publishers
 # @see docs/GITHUB_SETUP.md
 name: Publish
@@ -59,13 +60,50 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  publish:
-    name: Publish to npm (main)
+  release-check:
+    name: Check unpublished version (main)
     runs-on: ubuntu-latest
     if: >
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.head_branch == 'main')
+    outputs:
+      needs_publish: ${{ steps.check.outputs.needs_publish }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+
+      - name: Check registry
+        id: check
+        run: |
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "${NAME}@${VERSION}" version >/dev/null 2>&1; then
+            echo "needs_publish=false" >> "$GITHUB_OUTPUT"
+            echo "${NAME}@${VERSION} is already on npm — nothing to publish for this merge." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "needs_publish=true" >> "$GITHUB_OUTPUT"
+            echo "${NAME}@${VERSION} is not on npm — publish will run." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  publish:
+    name: Publish to npm (main)
+    runs-on: ubuntu-latest
+    needs: release-check
+    if: >
+      needs.release-check.outputs.needs_publish == 'true' &&
+      ((github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
+       (github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'main'))
 
     steps:
       - name: Checkout

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -25,7 +25,7 @@ flowchart LR
 Merge feature work with a `.changeset/*.md` file to **`dev`**. After CI passes, **Publish → Version packages (dev)** opens a **“Version Packages”** PR against `dev` (bumps `package.json`, updates `CHANGELOG.md`).
 
 **Phase 2 — ship (merge to `main`)**  
-Review and merge the Version Packages PR on `dev`, then merge **`dev` → `main`**. After CI on `main`, **Publish → Publish to npm** uploads the new version (OIDC).
+Review and merge the Version Packages PR on `dev`, then merge **`dev` → `main`** only when the version in `package.json` is **not yet on npm**. After CI on `main`, **Publish → Publish to npm** runs only for unpublished versions (strict `npm publish` — fails if the version already exists).
 
 Changelog entries come from changeset summaries and `@changesets/changelog-github` (links PRs/issues). You do not edit `CHANGELOG.md` by hand for releases.
 
@@ -72,7 +72,8 @@ One-time configuration: **[docs/GITHUB_SETUP.md](docs/GITHUB_SETUP.md)**.
 | Problem | Check |
 |---------|--------|
 | Version PR never opens | Changeset merged to **`dev`**? CI passed on `dev`? |
-| Publish fails with “already published” | Version on `main` matches npm — bump via Changesets on `dev` before merging to `main` again |
+| Publish fails with “already published” | `main` has a version already on npm — merge a **Version Packages** bump on `dev` first, then merge `dev` → `main` again |
+| Publish job skipped on `main` | Expected when merging `dev` → `main` without a new version (e.g. workflow-only changes); check **Check unpublished version** job summary |
 | `ENEEDAUTH` / 401 | Trusted Publishing: workflow **`publish.yml`**, repo match, `id-token: write` |
 | Wrong version bumped | Changeset type in `.changeset/*.md` |
 

--- a/docs/GITHUB_SETUP.md
+++ b/docs/GITHUB_SETUP.md
@@ -32,7 +32,7 @@ After **CI** succeeds on **`dev`** or **`main`**, [`.github/workflows/publish.ym
 | Branch | Job | What happens |
 |--------|-----|----------------|
 | **`dev`** | Version packages | Opens **Version Packages** PR if `.changeset/` files exist |
-| **`main`** | Publish to npm | Runs **`npm publish`** (OIDC); fails if that version already exists |
+| **`main`** | Publish to npm | Only if `package.json` version is **not** on npm yet; then strict `npm publish` (OIDC) |
 
 So you will **not** see a separate `run: npm publish` step in the YAML list — the [Changesets action](https://github.com/changesets/action) runs it for you via its `publish:` input when it is time to release. On npm, the allowed action **`npm publish`** still matches that command.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "three-iges-loader",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "TypeScript IGES loader for Three.js — parser + wireframe tessellation",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
…ow to check for unpublished versions before npm publish. Adjust documentation to reflect new publishing conditions.

## Summary

<!-- What does this PR do? Link issues: Fixes # -->

## Type of change

- [ ] Bug fix (patch)
- [ ] New feature / entity (minor)
- [ ] Breaking change (major)
- [ ] Documentation only
- [ ] Internal refactor (no user-visible change)

## Changeset

- [ ] I have run `pnpm changeset` (required for user-visible changes to `three-iges-loader`)
- [ ] Not needed (docs-only / internal-only — explain below)

## Checklist

- [ ] `pnpm type-check` passes
- [ ] `pnpm lint` and `pnpm format:check` pass
- [ ] `pnpm test` passes
- [ ] New IGES fixtures use **80-column** lines (section letter in column 73) if applicable
- [ ] Entity work follows [docs/ENTITY_IMPLEMENTATION.md](../docs/ENTITY_IMPLEMENTATION.md)

## AI-assisted

- [ ] I used AI tools and reviewed the diff against [AGENTS.md](../AGENTS.md)
